### PR TITLE
Separate tiller axis support

### DIFF
--- a/Config/aircraft-data.xml
+++ b/Config/aircraft-data.xml
@@ -3,7 +3,7 @@
 <PropertyList>
 
   <!--<path>/instrumentation/GROZA/settings/tcas-blip-radius</path>-->
-
+  <path>/controls/gear/separate-tiller-axis</path>
   <path>/tu154/options/keyboard/keyboard-mode</path>
   <path>/tu154/options/keyboard/close-viewer</path>
   <path>/tu154/options/welcome/show-on-startup</path>

--- a/Config/controls.xml
+++ b/Config/controls.xml
@@ -5,6 +5,8 @@
   <gear>
     <steering>63.0</steering>
     <nose-wheel-steering type="bool">false</nose-wheel-steering>
+    <tiller type="double">0</tiller>
+    <separate-tiller-axis type="bool">true</separate-tiller-axis>
   </gear>
 
 </PropertyList>

--- a/Config/controls.xml
+++ b/Config/controls.xml
@@ -6,7 +6,7 @@
     <steering>63.0</steering>
     <nose-wheel-steering type="bool">false</nose-wheel-steering>
     <tiller type="double">0</tiller>
-    <separate-tiller-axis type="bool">true</separate-tiller-axis>
+    <separate-tiller-axis type="bool">false</separate-tiller-axis>
   </gear>
 
 </PropertyList>

--- a/Model/Cockpit/cockpit.xml
+++ b/Model/Cockpit/cockpit.xml
@@ -1068,6 +1068,7 @@
     <factor>50</factor>
     <condition>
       <not><property>tu154/switches/steering-limit</property></not>
+      <not><property>/controls/gear/separate-tiller-axis</property></not>
     </condition>
     <axis>
       <x1-m>0.723</x1-m>
@@ -1078,6 +1079,25 @@
       <z2-m>0.524</z2-m>
     </axis>
   </animation>
+
+  <animation>
+  <type>rotate</type>
+  <object-name>taxi_handle</object-name>
+  <property>controls/gear/tiller</property>
+  <factor>-50</factor>
+  <condition>
+    <not><property>tu154/switches/steering-limit</property></not>
+    <property>/controls/gear/separate-tiller-axis</property>
+  </condition>
+  <axis>
+    <x1-m>0.723</x1-m>
+    <y1-m>-0.815</y1-m>
+    <z1-m>0.535</z1-m>
+    <x2-m>0.7015</x2-m>
+    <y2-m>-0.825</y2-m>
+    <z2-m>0.524</z2-m>
+  </axis>
+</animation>
 
 
   <!--Gear handle-->

--- a/gui/dialogs/preferences.xml
+++ b/gui/dialogs/preferences.xml
@@ -125,6 +125,26 @@
 
       <text><label> </label></text>
 
+      <group>
+        <layout>hbox</layout>
+        <hrule>
+          <stretch type="bool">true</stretch>
+        </hrule>
+        <text>
+          <label>Joystick</label>
+        </text>
+        <hrule>
+          <stretch type="bool">true</stretch>
+        </hrule>
+      </group>
+      <checkbox>
+        <halign>left</halign>
+        <label>Separate tiller axis</label>
+        <property>/controls/gear/separate-tiller-axis</property>
+        <live>true</live>
+        <binding><command>dialog-apply</command></binding>
+      </checkbox>
+
       <group><layout>hbox</layout>
         <hrule>
           <stretch type="bool">true</stretch>

--- a/tu154b.xml
+++ b/tu154b.xml
@@ -1047,7 +1047,17 @@
             </function>
           </fcs_function>
 
-          <switch name="gear/steering-cmd-norm">
+	  <fcs_function name="gear/tiller-cmd-scaled">
+	    <function>
+	      <product>
+		<property>/controls/gear/tiller</property>
+		<value>0.015873</value>
+		<property>gear/steering</property>
+              </product>
+            </function>
+          </fcs_function>
+
+         <switch name="gear/steering-cmd-norm">
             <test value="0">
               gear/unit[0]/WOW == 0
               gear/steering-cmd-norm lt 0.25
@@ -1056,7 +1066,13 @@
             <test value="gear/steering-cmd-norm">
               gear/unit[0]/WOW == 0
             </test>
-            <test value="-gear/rudder-cmd-scaled">
+            <test value="-gear/tiller-cmd-scaled">
+              /controls/gear/separate-tiller-axis == 1
+              gear/nose-wheel-steering == 1
+              systems/electrical-ok == 1
+              hs/hs2-busters-ok == 1
+            </test>
+            <test value="-gear/rudder-cmd-scaled">              
               gear/nose-wheel-steering == 1
               systems/electrical-ok == 1
               hs/hs2-busters-ok == 1

--- a/tu154b.xml
+++ b/tu154b.xml
@@ -1047,12 +1047,12 @@
             </function>
           </fcs_function>
 
-	  <fcs_function name="gear/tiller-cmd-scaled">
-	    <function>
-	      <product>
-		<property>/controls/gear/tiller</property>
-		<value>0.015873</value>
-		<property>gear/steering</property>
+	        <fcs_function name="gear/tiller-cmd-scaled">
+	          <function>
+	            <product>
+		            <property>/controls/gear/tiller</property>
+		            <value>0.015873</value>
+		            <property>gear/steering</property>
               </product>
             </function>
           </fcs_function>


### PR DESCRIPTION
The tiller axis can now be mapped to a separate joystick axis. This functionality may be turned off in the Preferences dialog or by setting the property '/controls/gear/separate-tiller-axis' to false; the original behaviour (tiller mapped to the rudder axis) will then apply.

Map the tiller joystick to the property '/controls/gear/tiller'.

The model has also been updated so that the tiller control handle in the virtual cockpit moves accordingly in both modes.